### PR TITLE
Use Firestore Data for tracking progress bar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -387,6 +387,29 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<double> _getPlantPercent() async {
     DocumentSnapshot doc = await _getUserData();
+    
+    double percent = 0;
+    int plantCount = 0, totalCount = 0;
+    // TODO: add error catching/handling
+    QuerySnapshot querySnapshot = await Firestore.instance.collection('users').document(await auth.getCurrentUser()).collection('meals').getDocuments();
+    List<DocumentSnapshot> meals = querySnapshot.documents;
+    meals.forEach((meal) => {
+      if (meal.data['mealType'] == "Vegetarian" || meal.data['mealType'] == "Vegan" ) {
+        plantCount += 1
+      },
+      totalCount += 1
+    } );
+    setState(() {
+      percent = plantCount / totalCount;
+      return percent;
+    });
+
+    return 1;
+
+    setState(() {
+      // TODO:
+    });
+
     int count = 0;
     int veg = 0;
     if(doc['Count'] != null) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -390,40 +390,26 @@ class _MyHomePageState extends State<MyHomePage> {
     
     double percent = 0;
     int plantCount = 0, totalCount = 0;
-    // TODO: add error catching/handling
-    QuerySnapshot querySnapshot = await Firestore.instance.collection('users').document(await auth.getCurrentUser()).collection('meals').getDocuments();
-    List<DocumentSnapshot> meals = querySnapshot.documents;
-    meals.forEach((meal) => {
-      if (meal.data['mealType'] == "Vegetarian" || meal.data['mealType'] == "Vegan" ) {
-        plantCount += 1
-      },
-      totalCount += 1
-    } );
-    setState(() {
+    try {
+      QuerySnapshot querySnapshot = await Firestore.instance.collection('users')
+          .document(await auth.getCurrentUser()).collection('meals')
+          .getDocuments();
+      List<DocumentSnapshot> meals = querySnapshot.documents;
+      meals.forEach((meal) =>
+      {
+        if (meal.data['type'] == "Vegetarian" ||
+            meal.data['type'] == "Vegan" ) {
+          plantCount += 1
+        },
+        totalCount += 1
+      });
+
       percent = plantCount / totalCount;
-      return percent;
-    });
-
-    return 1;
-
-    setState(() {
-      // TODO:
-    });
-
-    int count = 0;
-    int veg = 0;
-    if(doc['Count'] != null) {
-      count = doc['Count'];
-    }
-    if (doc['Vegetarian'] != null) {
-      veg += doc['Vegetarian'];
-    }
-    if (doc['Vegan'] != null) {
-      veg += doc['Vegan'];
+    } catch(e) {
+      print("Not able to get track data properly"); // TODO: maybe add error display for user
     }
 
-    if(count == 0 || veg > count ) { return 0; }
-    else { return veg / count; }
+    return percent;
   }
 
   /// Returns the TRACK Column.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,10 +50,7 @@ dev_dependencies:
 # The following section is specific to Flutter.
 flutter:
   assets:
-    - assets/grass.JPG
-    - assets/skygrass.JPG
-    - assets/praireygrass.JPG
-    - assets/learn_background/customgrass.PNG
+    - assets/
     - assets/goal_progress/
     - assets/learn_background/
 


### PR DESCRIPTION
This branch makes the progress bar on the track page use the list of meals.

I intentionally am requesting to merge this branch into Refactor/Eat. I used what you had done on that branch so far so that it would be easier to merge both of them into master (this may have been a mistake, but too late now). There are still bugs in it, but those are the same bugs that are in Refactor/Eat because it isn't complete.