### PR TITLE
Reliable iOS MissingPluginException fix

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -212,10 +212,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: bce82c76043657c99d91e7882e8a9e1a93650cd4
   BoringSSL-GRPC: db8764df3204ccea016e1c8dd15d9a9ad63ff318
-  cloud_firestore: 2d82a8ddea1ac2f535ec891ed68b5975fe4f9509
+  cloud_firestore: 187530401afa261d255791ea75580591e345fa7b
   Firebase: 5e6b7b12bf9adb90986688edc06b156c37e109cd
   firebase_analytics: 045e7ebe7b8a4d27357168072868ff082dca15a6
-  firebase_auth: 1e3b7bdd37b9fbd4ef75ba1d985b00be09e02d3d
+  firebase_auth: d99b993c1405096e66c58211b1cd956c23eed1c5
   firebase_core: ae55ea92448ec8675d325da4db22cf3b4d58a54d
   FirebaseAnalytics: 0e3ecff2c5d86070f7d4325e21f1edabfbd558dc
   FirebaseAuth: c66e990f79d1d3429165391f6cd70ace6143c25e

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,15 +1,13 @@
 import UIKit
-import Firebase
+import Flutter
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
-
-  var window: UIWindow?
-
-  func application(_ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions:
-      [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-    FirebaseApp.configure()
-    return true
+@objc class AppDelegate: FlutterAppDelegate {
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    GeneratedPluginRegistrant.register(with: self)
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }


### PR DESCRIPTION
Be sure to revert the old fix **first**.

Changed only one file for iOS this time instead of rebuilding its app. Tested three different times after `flutter clean` and `flutter packages get` just in case, and it is no longer crashing on Android. But do test it to make sure.

For any conflicts, just accept the new changes. They only affect the `ios` portion of the code and simply revert the `AppDelegate.swift` to its original form and sets `cloud_firestore` and `firebase_auth` to functioning versions (auto generated on build).