### PR TITLE
Removes Login Back Button

### DIFF
--- a/lib/drawer.dart
+++ b/lib/drawer.dart
@@ -146,7 +146,7 @@ class GGDrawer {
             onTap: () {
               auth.signOut();
               Navigator.pop(context); // close drawer
-              Navigator.pushNamed(context, MyApp.getLoginRouteName());
+              Navigator.pushReplacementNamed(context, MyApp.getLoginRouteName());
             },
           );
         } else {
@@ -161,7 +161,7 @@ class GGDrawer {
             ),
             onTap: () {
               Navigator.pop(context); // close drawer
-              Navigator.pushNamed(context, MyApp.getLoginRouteName());
+              Navigator.pushReplacementNamed(context, MyApp.getLoginRouteName());
             },
           );
         }

--- a/lib/login.dart
+++ b/lib/login.dart
@@ -6,6 +6,7 @@
 import 'package:flutter/material.dart';
 import 'package:grassroots_green/auth.dart';
 import 'package:email_validator/email_validator.dart';
+import 'package:grassroots_green/main.dart';
 
 class Login extends StatelessWidget {
   /// Login page of the app.
@@ -53,8 +54,8 @@ class LoginStatefulWidget extends StatefulWidget {
   _LoginStatefulWidgetState createState() => _LoginStatefulWidgetState();
 
   /// Post-sign in action.
-  void onSignedIn(BuildContext context) {
-    Navigator.pop(context);
+  StatefulWidget onSignedIn(BuildContext context) {
+    Navigator.pushReplacementNamed(context, MyHomePage.routeName);
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -119,7 +119,7 @@ class _MyHomePageState extends State<MyHomePage> {
   _MyHomePageState({this.auth}) {
     auth.isSignedIn().then( (result) {
       if (!result) {
-        Navigator.pushNamed(context, MyApp.getLoginRouteName());
+        Navigator.pushReplacementNamed(context, MyApp.getLoginRouteName());
       }
     });
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -65,6 +65,7 @@ class MyApp extends StatelessWidget {
         Login.routeName: (context) => Login(auth: auth),
         Compete.routeName: (context) => Compete(auth: auth),
         MealList.routeName: (context) => MealList(auth: auth),
+        MyHomePage.routeName: (context) => MyHomePage(auth: auth)
       },
 
       //When a route is generated, return the route to page,
@@ -98,6 +99,8 @@ class MyHomePage extends StatefulWidget {
 
   /// Information about authenticated user.
   final BaseAuth auth;
+
+  static const String routeName = '\homePage';
 
   @override
   _MyHomePageState createState() => _MyHomePageState(auth: auth);


### PR DESCRIPTION
Changed a few things in order to fix #99 

- changed `pushNamed()` to `pushReplacementNamed()` in a few places
- added `routeName` for home page so that login.dart could `pushReplacementNamed()` after logging in rather than using `pop()`

I tested various scenarios like logging in, logging out and logging back in, as well as logging out and creating a new account. They all seem to be working. Please do test it for yourselves just in case.